### PR TITLE
Fix issue where sysex is never enabled when using webmidi api directly.

### DIFF
--- a/firefox/web-midi/content.js
+++ b/firefox/web-midi/content.js
@@ -1,7 +1,7 @@
 if (document instanceof HTMLDocument && !navigator.requestMIDIAccess) {
   var script = document.createElement("script");
-  script.textContent = "\n\n/// begin: [code injected by Web MIDI API browser extension]\nnavigator.requestMIDIAccess=function(){if(typeof JZZ=='undefined')window.JZZ=(" +
+  script.textContent = "\n\n/// begin: [code injected by Web MIDI API browser extension]\nnavigator.requestMIDIAccess=function(MIDIOptions){if(typeof JZZ=='undefined')window.JZZ=(" +
     _JZZ.toString() +
-    ")();navigator.requestMIDIAccess = JZZ.requestMIDIAccess;return navigator.requestMIDIAccess();}\n/// end: [code injected by Web MIDI API browser extension]\n\n";
+    ")();navigator.requestMIDIAccess = JZZ.requestMIDIAccess;return navigator.requestMIDIAccess(MIDIOptions);}\n/// end: [code injected by Web MIDI API browser extension]\n\n";
   document.documentElement.appendChild(script);
 }


### PR DESCRIPTION
I noticed when testing in different browsers that idiomatic WebMIDI spec code does not work in Firefox - sysex support is never enabled, because any arguments to `requestMIDIAccess` are discarded in the Firefox content script. JZZ-midi-gear works around this somehow, but sysex isn't possible by following the spec. This is a simple fix to the content script to address this, but unsure if there are any side-effects.

Here's an example that works in chrome, doesn't work using the current published version of the web-midi extension, but does work with this change.

https://codepen.io/canuckistani-1471644214/pen/QWGdbrq?editors=1010

```javascript
navigator.requestMIDIAccess({sysex: true}).then((access)  => {
  console.log(access.sysexEnabled);
  
  setTimeout(function() {
     document.querySelector('h1#answer')
       .textContent = access.sysexEnabled ? "⚡️Yes! 🎹⚡️" : "🚫 NO 🚫";
  }, 750); 

  access.onstatechange = function(e) {
    // Print information about the (dis)connected MIDI controller
    console.log(e.port.name, e.port.manufacturer, e.port.state);
  };
});
```